### PR TITLE
Fixed name shadowing warnings

### DIFF
--- a/include/boost/date_time/gregorian/gregorian_io.hpp
+++ b/include/boost/date_time/gregorian/gregorian_io.hpp
@@ -77,14 +77,14 @@ namespace gregorian {
     typename std::basic_istream<CharT, Traits>::sentry strm_sentry(is, false); 
     if (strm_sentry) {
       try {
-        typedef typename date_time::date_input_facet<date, CharT> date_input_facet;
+        typedef typename date_time::date_input_facet<date, CharT> facet_type;
         
         std::istreambuf_iterator<CharT,Traits> sit(is), str_end;
-        if(std::has_facet<date_input_facet>(is.getloc())) {
-          std::use_facet<date_input_facet>(is.getloc()).get(sit, str_end, is, d);
+        if(std::has_facet<facet_type>(is.getloc())) {
+          std::use_facet<facet_type>(is.getloc()).get(sit, str_end, is, d);
         }
         else {
-          date_input_facet* f = new date_input_facet();
+          facet_type* f = new facet_type();
           std::locale l = std::locale(is.getloc(), f);
           is.imbue(l);
           f->get(sit, str_end, is, d);
@@ -138,14 +138,14 @@ namespace gregorian {
     typename std::basic_istream<CharT, Traits>::sentry strm_sentry(is, false); 
     if (strm_sentry) {
       try {
-        typedef typename date_time::date_input_facet<date, CharT> date_input_facet;
+        typedef typename date_time::date_input_facet<date, CharT> facet_type;
         
         std::istreambuf_iterator<CharT,Traits> sit(is), str_end;
-        if(std::has_facet<date_input_facet>(is.getloc())) {
-          std::use_facet<date_input_facet>(is.getloc()).get(sit, str_end, is, dd);
+        if(std::has_facet<facet_type>(is.getloc())) {
+          std::use_facet<facet_type>(is.getloc()).get(sit, str_end, is, dd);
         }
         else {
-          date_input_facet* f = new date_input_facet();
+          facet_type* f = new facet_type();
           std::locale l = std::locale(is.getloc(), f);
           is.imbue(l);
           f->get(sit, str_end, is, dd);
@@ -202,14 +202,14 @@ namespace gregorian {
     typename std::basic_istream<CharT, Traits>::sentry strm_sentry(is, false); 
     if (strm_sentry) {
       try {
-        typedef typename date_time::date_input_facet<date, CharT> date_input_facet;
+        typedef typename date_time::date_input_facet<date, CharT> facet_type;
 
         std::istreambuf_iterator<CharT,Traits> sit(is), str_end;
-        if(std::has_facet<date_input_facet>(is.getloc())) {
-          std::use_facet<date_input_facet>(is.getloc()).get(sit, str_end, is, dp);
+        if(std::has_facet<facet_type>(is.getloc())) {
+          std::use_facet<facet_type>(is.getloc()).get(sit, str_end, is, dp);
         }
         else {
-          date_input_facet* f = new date_input_facet();
+          facet_type* f = new facet_type();
           std::locale l = std::locale(is.getloc(), f);
           is.imbue(l);
           f->get(sit, str_end, is, dp);
@@ -261,14 +261,14 @@ namespace gregorian {
     typename std::basic_istream<CharT, Traits>::sentry strm_sentry(is, false); 
     if (strm_sentry) {
       try {
-        typedef typename date_time::date_input_facet<date, CharT> date_input_facet;
+        typedef typename date_time::date_input_facet<date, CharT> facet_type;
 
         std::istreambuf_iterator<CharT,Traits> sit(is), str_end;
-        if(std::has_facet<date_input_facet>(is.getloc())) {
-          std::use_facet<date_input_facet>(is.getloc()).get(sit, str_end, is, m);
+        if(std::has_facet<facet_type>(is.getloc())) {
+          std::use_facet<facet_type>(is.getloc()).get(sit, str_end, is, m);
         }
         else {
-          date_input_facet* f = new date_input_facet();
+          facet_type* f = new facet_type();
           std::locale l = std::locale(is.getloc(), f);
           is.imbue(l);
           f->get(sit, str_end, is, m);
@@ -318,14 +318,14 @@ namespace gregorian {
     typename std::basic_istream<CharT, Traits>::sentry strm_sentry(is, false); 
     if (strm_sentry) {
       try {
-        typedef typename date_time::date_input_facet<date, CharT> date_input_facet;
+        typedef typename date_time::date_input_facet<date, CharT> facet_type;
 
         std::istreambuf_iterator<CharT,Traits> sit(is), str_end;
-        if(std::has_facet<date_input_facet>(is.getloc())) {
-          std::use_facet<date_input_facet>(is.getloc()).get(sit, str_end, is, wd);
+        if(std::has_facet<facet_type>(is.getloc())) {
+          std::use_facet<facet_type>(is.getloc()).get(sit, str_end, is, wd);
         }
         else {
-          date_input_facet* f = new date_input_facet();
+          facet_type* f = new facet_type();
           std::locale l = std::locale(is.getloc(), f);
           is.imbue(l);
           f->get(sit, str_end, is, wd);
@@ -359,14 +359,14 @@ namespace gregorian {
     typename std::basic_istream<CharT, Traits>::sentry strm_sentry(is, false); 
     if (strm_sentry) {
       try {
-        typedef typename date_time::date_input_facet<date, CharT> date_input_facet;
+        typedef typename date_time::date_input_facet<date, CharT> facet_type;
 
         std::istreambuf_iterator<CharT,Traits> sit(is), str_end;
-        if(std::has_facet<date_input_facet>(is.getloc())) {
-          std::use_facet<date_input_facet>(is.getloc()).get(sit, str_end, is, gd);
+        if(std::has_facet<facet_type>(is.getloc())) {
+          std::use_facet<facet_type>(is.getloc()).get(sit, str_end, is, gd);
         }
         else {
-          date_input_facet* f = new date_input_facet();
+          facet_type* f = new facet_type();
           std::locale l = std::locale(is.getloc(), f);
           is.imbue(l);
           f->get(sit, str_end, is, gd);
@@ -400,14 +400,14 @@ namespace gregorian {
     typename std::basic_istream<CharT, Traits>::sentry strm_sentry(is, false); 
     if (strm_sentry) {
       try {
-        typedef typename date_time::date_input_facet<date, CharT> date_input_facet;
+        typedef typename date_time::date_input_facet<date, CharT> facet_type;
 
         std::istreambuf_iterator<CharT,Traits> sit(is), str_end;
-        if(std::has_facet<date_input_facet>(is.getloc())) {
-          std::use_facet<date_input_facet>(is.getloc()).get(sit, str_end, is, gy);
+        if(std::has_facet<facet_type>(is.getloc())) {
+          std::use_facet<facet_type>(is.getloc()).get(sit, str_end, is, gy);
         }
         else {
-          date_input_facet* f = new date_input_facet();
+          facet_type* f = new facet_type();
           std::locale l = std::locale(is.getloc(), f);
           is.imbue(l);
           f->get(sit, str_end, is, gy);
@@ -458,14 +458,14 @@ namespace gregorian {
     typename std::basic_istream<CharT, Traits>::sentry strm_sentry(is, false); 
     if (strm_sentry) {
       try {
-        typedef typename date_time::date_input_facet<date, CharT> date_input_facet;
+        typedef typename date_time::date_input_facet<date, CharT> facet_type;
 
         std::istreambuf_iterator<CharT,Traits> sit(is), str_end;
-        if(std::has_facet<date_input_facet>(is.getloc())) {
-          std::use_facet<date_input_facet>(is.getloc()).get(sit, str_end, is, pd);
+        if(std::has_facet<facet_type>(is.getloc())) {
+          std::use_facet<facet_type>(is.getloc()).get(sit, str_end, is, pd);
         }
         else {
-          date_input_facet* f = new date_input_facet();
+          facet_type* f = new facet_type();
           std::locale l = std::locale(is.getloc(), f);
           is.imbue(l);
           f->get(sit, str_end, is, pd);
@@ -515,14 +515,14 @@ namespace gregorian {
     typename std::basic_istream<CharT, Traits>::sentry strm_sentry(is, false); 
     if (strm_sentry) {
       try {
-        typedef typename date_time::date_input_facet<date, CharT> date_input_facet;
+        typedef typename date_time::date_input_facet<date, CharT> facet_type;
 
         std::istreambuf_iterator<CharT,Traits> sit(is), str_end;
-        if(std::has_facet<date_input_facet>(is.getloc())) {
-          std::use_facet<date_input_facet>(is.getloc()).get(sit, str_end, is, nday);
+        if(std::has_facet<facet_type>(is.getloc())) {
+          std::use_facet<facet_type>(is.getloc()).get(sit, str_end, is, nday);
         }
         else {
-          date_input_facet* f = new date_input_facet();
+          facet_type* f = new facet_type();
           std::locale l = std::locale(is.getloc(), f);
           is.imbue(l);
           f->get(sit, str_end, is, nday);
@@ -573,14 +573,14 @@ namespace gregorian {
     typename std::basic_istream<CharT, Traits>::sentry strm_sentry(is, false); 
     if (strm_sentry) {
       try {
-        typedef typename date_time::date_input_facet<date, CharT> date_input_facet;
+        typedef typename date_time::date_input_facet<date, CharT> facet_type;
 
         std::istreambuf_iterator<CharT,Traits> sit(is), str_end;
-        if(std::has_facet<date_input_facet>(is.getloc())) {
-          std::use_facet<date_input_facet>(is.getloc()).get(sit, str_end, is, fkd);
+        if(std::has_facet<facet_type>(is.getloc())) {
+          std::use_facet<facet_type>(is.getloc()).get(sit, str_end, is, fkd);
         }
         else {
-          date_input_facet* f = new date_input_facet();
+          facet_type* f = new facet_type();
           std::locale l = std::locale(is.getloc(), f);
           is.imbue(l);
           f->get(sit, str_end, is, fkd);
@@ -631,14 +631,14 @@ namespace gregorian {
     typename std::basic_istream<CharT, Traits>::sentry strm_sentry(is, false); 
     if (strm_sentry) {
       try {
-        typedef typename date_time::date_input_facet<date, CharT> date_input_facet;
+        typedef typename date_time::date_input_facet<date, CharT> facet_type;
 
         std::istreambuf_iterator<CharT,Traits> sit(is), str_end;
-        if(std::has_facet<date_input_facet>(is.getloc())) {
-          std::use_facet<date_input_facet>(is.getloc()).get(sit, str_end, is, lkd);
+        if(std::has_facet<facet_type>(is.getloc())) {
+          std::use_facet<facet_type>(is.getloc()).get(sit, str_end, is, lkd);
         }
         else {
-          date_input_facet* f = new date_input_facet();
+          facet_type* f = new facet_type();
           std::locale l = std::locale(is.getloc(), f);
           is.imbue(l);
           f->get(sit, str_end, is, lkd);
@@ -690,14 +690,14 @@ namespace gregorian {
     typename std::basic_istream<CharT, Traits>::sentry strm_sentry(is, false); 
     if (strm_sentry) {
       try {
-        typedef typename date_time::date_input_facet<date, CharT> date_input_facet;
+        typedef typename date_time::date_input_facet<date, CharT> facet_type;
 
         std::istreambuf_iterator<CharT,Traits> sit(is), str_end;
-        if(std::has_facet<date_input_facet>(is.getloc())) {
-          std::use_facet<date_input_facet>(is.getloc()).get(sit, str_end, is, fka);
+        if(std::has_facet<facet_type>(is.getloc())) {
+          std::use_facet<facet_type>(is.getloc()).get(sit, str_end, is, fka);
         }
         else {
-          date_input_facet* f = new date_input_facet();
+          facet_type* f = new facet_type();
           std::locale l = std::locale(is.getloc(), f);
           is.imbue(l);
           f->get(sit, str_end, is, fka);
@@ -749,14 +749,14 @@ namespace gregorian {
     typename std::basic_istream<CharT, Traits>::sentry strm_sentry(is, false); 
     if (strm_sentry) {
       try {
-        typedef typename date_time::date_input_facet<date, CharT> date_input_facet;
+        typedef typename date_time::date_input_facet<date, CharT> facet_type;
 
         std::istreambuf_iterator<CharT,Traits> sit(is), str_end;
-        if(std::has_facet<date_input_facet>(is.getloc())) {
-          std::use_facet<date_input_facet>(is.getloc()).get(sit, str_end, is, fkb);
+        if(std::has_facet<facet_type>(is.getloc())) {
+          std::use_facet<facet_type>(is.getloc()).get(sit, str_end, is, fkb);
         }
         else {
-          date_input_facet* f = new date_input_facet();
+          facet_type* f = new facet_type();
           std::locale l = std::locale(is.getloc(), f);
           is.imbue(l);
           f->get(sit, str_end, is, fkb);


### PR DESCRIPTION
Fixes following warnings:

```
In file included from ../../../boost/date_time/gregorian/gregorian.hpp:31:0,
                 from karma/basic_facilities.cpp:30:
../../../boost/date_time/gregorian/gregorian_io.hpp: In function ‘std::basic_istream<_CharT, _Traits>& boost::gregorian::operator>>(std::basic_istream<_CharT, _Traits>&, boost::gregorian::date&)’:
../../../boost/date_time/gregorian/gregorian_io.hpp:80:67: warning: declaration of ‘date_input_facet’ shadows a global declaration [-Wshadow]
         typedef typename date_time::date_input_facet<date, CharT> date_input_facet;
                                                                   ^
../../../boost/date_time/gregorian/gregorian_io.hpp:43:60: note: shadowed declaration is here
   typedef boost::date_time::date_input_facet<date,char>    date_input_facet;
                                                            ^
../../../boost/date_time/gregorian/gregorian_io.hpp: In function ‘std::basic_istream<_CharT, _Traits>& boost::gregorian::operator>>(std::basic_istream<_CharT, _Traits>&, boost::gregorian::date_duration&)’:
../../../boost/date_time/gregorian/gregorian_io.hpp:141:67: warning: declaration of ‘date_input_facet’ shadows a global declaration [-Wshadow]
         typedef typename date_time::date_input_facet<date, CharT> date_input_facet;
                                                                   ^
../../../boost/date_time/gregorian/gregorian_io.hpp:43:60: note: shadowed declaration is here
   typedef boost::date_time::date_input_facet<date,char>    date_input_facet;
                                                            ^
../../../boost/date_time/gregorian/gregorian_io.hpp: In function ‘std::basic_istream<_CharT, _Traits>& boost::gregorian::operator>>(std::basic_istream<_CharT, _Traits>&, boost::gregorian::date_period&)’:
../../../boost/date_time/gregorian/gregorian_io.hpp:205:67: warning: declaration of ‘date_input_facet’ shadows a global declaration [-Wshadow]
         typedef typename date_time::date_input_facet<date, CharT> date_input_facet;
                                                                   ^
../../../boost/date_time/gregorian/gregorian_io.hpp:43:60: note: shadowed declaration is here
   typedef boost::date_time::date_input_facet<date,char>    date_input_facet;
                                                            ^
../../../boost/date_time/gregorian/gregorian_io.hpp: In function ‘std::basic_istream<_CharT, _Traits>& boost::gregorian::operator>>(std::basic_istream<_CharT, _Traits>&, boost::gregorian::greg_month&)’:
../../../boost/date_time/gregorian/gregorian_io.hpp:264:67: warning: declaration of ‘date_input_facet’ shadows a global declaration [-Wshadow]
         typedef typename date_time::date_input_facet<date, CharT> date_input_facet;
                                                                   ^
../../../boost/date_time/gregorian/gregorian_io.hpp:43:60: note: shadowed declaration is here
   typedef boost::date_time::date_input_facet<date,char>    date_input_facet;
                                                            ^
../../../boost/date_time/gregorian/gregorian_io.hpp: In function ‘std::basic_istream<_CharT, _Traits>& boost::gregorian::operator>>(std::basic_istream<_CharT, _Traits>&, boost::gregorian::greg_weekday&)’:
../../../boost/date_time/gregorian/gregorian_io.hpp:321:67: warning: declaration of ‘date_input_facet’ shadows a global declaration [-Wshadow]
         typedef typename date_time::date_input_facet<date, CharT> date_input_facet;
                                                                   ^
../../../boost/date_time/gregorian/gregorian_io.hpp:43:60: note: shadowed declaration is here
   typedef boost::date_time::date_input_facet<date,char>    date_input_facet;
                                                            ^
../../../boost/date_time/gregorian/gregorian_io.hpp: In function ‘std::basic_istream<_CharT, _Traits>& boost::gregorian::operator>>(std::basic_istream<_CharT, _Traits>&, boost::gregorian::greg_day&)’:
../../../boost/date_time/gregorian/gregorian_io.hpp:362:67: warning: declaration of ‘date_input_facet’ shadows a global declaration [-Wshadow]
         typedef typename date_time::date_input_facet<date, CharT> date_input_facet;
                                                                   ^
../../../boost/date_time/gregorian/gregorian_io.hpp:43:60: note: shadowed declaration is here
   typedef boost::date_time::date_input_facet<date,char>    date_input_facet;
                                                            ^
../../../boost/date_time/gregorian/gregorian_io.hpp: In function ‘std::basic_istream<_CharT, _Traits>& boost::gregorian::operator>>(std::basic_istream<_CharT, _Traits>&, boost::gregorian::greg_year&)’:
../../../boost/date_time/gregorian/gregorian_io.hpp:403:67: warning: declaration of ‘date_input_facet’ shadows a global declaration [-Wshadow]
         typedef typename date_time::date_input_facet<date, CharT> date_input_facet;
                                                                   ^
../../../boost/date_time/gregorian/gregorian_io.hpp:43:60: note: shadowed declaration is here
   typedef boost::date_time::date_input_facet<date,char>    date_input_facet;
                                                            ^
../../../boost/date_time/gregorian/gregorian_io.hpp: In function ‘std::basic_istream<_CharT, _Traits>& boost::gregorian::operator>>(std::basic_istream<_CharT, _Traits>&, boost::gregorian::partial_date&)’:
../../../boost/date_time/gregorian/gregorian_io.hpp:461:67: warning: declaration of ‘date_input_facet’ shadows a global declaration [-Wshadow]
         typedef typename date_time::date_input_facet<date, CharT> date_input_facet;
                                                                   ^
../../../boost/date_time/gregorian/gregorian_io.hpp:43:60: note: shadowed declaration is here
   typedef boost::date_time::date_input_facet<date,char>    date_input_facet;
                                                            ^
../../../boost/date_time/gregorian/gregorian_io.hpp: In function ‘std::basic_istream<_CharT, _Traits>& boost::gregorian::operator>>(std::basic_istream<_CharT, _Traits>&, boost::gregorian::nth_day_of_the_week_in_month&)’:
../../../boost/date_time/gregorian/gregorian_io.hpp:518:67: warning: declaration of ‘date_input_facet’ shadows a global declaration [-Wshadow]
         typedef typename date_time::date_input_facet<date, CharT> date_input_facet;
                                                                   ^
../../../boost/date_time/gregorian/gregorian_io.hpp:43:60: note: shadowed declaration is here
   typedef boost::date_time::date_input_facet<date,char>    date_input_facet;
                                                            ^
../../../boost/date_time/gregorian/gregorian_io.hpp: In function ‘std::basic_istream<_CharT, _Traits>& boost::gregorian::operator>>(std::basic_istream<_CharT, _Traits>&, boost::gregorian::first_day_of_the_week_in_month&)’:
../../../boost/date_time/gregorian/gregorian_io.hpp:576:67: warning: declaration of ‘date_input_facet’ shadows a global declaration [-Wshadow]
         typedef typename date_time::date_input_facet<date, CharT> date_input_facet;
                                                                   ^
../../../boost/date_time/gregorian/gregorian_io.hpp:43:60: note: shadowed declaration is here
   typedef boost::date_time::date_input_facet<date,char>    date_input_facet;
                                                            ^
../../../boost/date_time/gregorian/gregorian_io.hpp: In function ‘std::basic_istream<_CharT, _Traits>& boost::gregorian::operator>>(std::basic_istream<_CharT, _Traits>&, boost::gregorian::last_day_of_the_week_in_month&)’:
../../../boost/date_time/gregorian/gregorian_io.hpp:634:67: warning: declaration of ‘date_input_facet’ shadows a global declaration [-Wshadow]
         typedef typename date_time::date_input_facet<date, CharT> date_input_facet;
                                                                   ^
../../../boost/date_time/gregorian/gregorian_io.hpp:43:60: note: shadowed declaration is here
   typedef boost::date_time::date_input_facet<date,char>    date_input_facet;
                                                            ^
../../../boost/date_time/gregorian/gregorian_io.hpp: In function ‘std::basic_istream<_CharT, _Traits>& boost::gregorian::operator>>(std::basic_istream<_CharT, _Traits>&, boost::gregorian::first_day_of_the_week_after&)’:
../../../boost/date_time/gregorian/gregorian_io.hpp:693:67: warning: declaration of ‘date_input_facet’ shadows a global declaration [-Wshadow]
         typedef typename date_time::date_input_facet<date, CharT> date_input_facet;
                                                                   ^
../../../boost/date_time/gregorian/gregorian_io.hpp:43:60: note: shadowed declaration is here
   typedef boost::date_time::date_input_facet<date,char>    date_input_facet;
                                                            ^
../../../boost/date_time/gregorian/gregorian_io.hpp: In function ‘std::basic_istream<_CharT, _Traits>& boost::gregorian::operator>>(std::basic_istream<_CharT, _Traits>&, boost::gregorian::first_day_of_the_week_before&)’:
../../../boost/date_time/gregorian/gregorian_io.hpp:752:67: warning: declaration of ‘date_input_facet’ shadows a global declaration [-Wshadow]
         typedef typename date_time::date_input_facet<date, CharT> date_input_facet;
                                                                   ^
../../../boost/date_time/gregorian/gregorian_io.hpp:43:60: note: shadowed declaration is here
   typedef boost::date_time::date_input_facet<date,char>    date_input_facet;
                                                            ^
```
